### PR TITLE
Fixed the `fn test_weaver_constructor()` in the test file 

### DIFF
--- a/tests/test_weaver.cairo
+++ b/tests/test_weaver.cairo
@@ -53,7 +53,7 @@ fn __setup__() -> (ContractAddress, ContractAddress) {
 
 #[test]
 fn test_weaver_constructor() {
-    let weaver_contract_address = __setup__();
+    let (weaver_contract_address, nft_address) = __setup__();
 
     let weaver_contract = IWeaverDispatcher { contract_address: weaver_contract_address };
 


### PR DESCRIPTION
 The main issue is that the __setup__() function returns a tuple of two addresses, but the test is only using one value.