### PR TITLE
feat(protocol): implement create_task function

### DIFF
--- a/src/mods/interfaces/Iprotocol.cairo
+++ b/src/mods/interfaces/Iprotocol.cairo
@@ -10,7 +10,7 @@ pub trait IProtocol<TState> {
     fn create_protocol_campaign(ref self: TState, protocol_id: u256) -> u256;
     fn join_protocol_campaign(ref self: TState, campaign_user: ContractAddress, protocol_id: u256);
     fn set_protocol_matadata_uri(ref self: TState, protocol_id: u256, matadata_uri: ByteArray);
-    fn create_task(ref self: TState, task_id: u256) -> u256;
+    fn create_task(ref self: TState, task_id: u256, task_description: ByteArray) -> u256;
 
 
     fn is_task_complete(ref self: TState, campaign_user: ContractAddress, task_id: u256) -> bool;

--- a/src/mods/protocol/protocolcomponent.cairo
+++ b/src/mods/protocol/protocolcomponent.cairo
@@ -155,13 +155,26 @@ pub mod ProtocolCampagin {
         }
 
 
-        fn create_task(ref self: ComponentState<TContractState>, task_id: u256) -> u256 {
+        fn create_task(ref self: ComponentState<TContractState>, task_id: u256, task_description: ByteArray) -> u256 {
             // Get the caller as the protocol owner by using the get_caller_address()
+            let protocol_owner = get_caller_address();
 
             // Check if the task_id exist by reading from state i.e tasks_initialized
             // and also assert if it exist  Errors::TASK_ALREADY_EXIST
+            let task_exists = self.tasks_initialized.read(task_id);
+            assert(!task_exists, Errors::TASK_ALREADY_EXIST);
+
+            let protocol_id = self.protocol_id.read();
+            let protocol_owner_stored = self.protocol_owner.read(protocol_id);
+            assert(protocol_owner == protocol_owner_stored, Errors::UNAUTHORIZED);
 
             // call the internal function _create_task
+            self._create_task(
+                protocol_id,
+                task_id,
+                task_description,
+                protocol_owner
+            );
 
             return task_id;
         }

--- a/src/mods/protocol/protocolcomponent.cairo
+++ b/src/mods/protocol/protocolcomponent.cairo
@@ -155,7 +155,9 @@ pub mod ProtocolCampagin {
         }
 
 
-        fn create_task(ref self: ComponentState<TContractState>, task_id: u256, task_description: ByteArray) -> u256 {
+        fn create_task(
+            ref self: ComponentState<TContractState>, task_id: u256, task_description: ByteArray
+        ) -> u256 {
             // Get the caller as the protocol owner by using the get_caller_address()
             let protocol_owner = get_caller_address();
 
@@ -169,12 +171,7 @@ pub mod ProtocolCampagin {
             assert(protocol_owner == protocol_owner_stored, Errors::UNAUTHORIZED);
 
             // call the internal function _create_task
-            self._create_task(
-                protocol_id,
-                task_id,
-                task_description,
-                protocol_owner
-            );
+            self._create_task(protocol_id, task_id, task_description, protocol_owner);
 
             return task_id;
         }


### PR DESCRIPTION
- Complete implementation of create_task() function in ProtocolCampagin component
- Task duplication verification using task_initialized
- Authorization validation to ensure only protocol owner can create tasks
- Adheres to interface defined in Iprotocol.cairo"