### PR TITLE
Implement Protocol Campaign Creation with Owner and NFT Handling

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 scarb 2.8.5
+starknet-foundry 0.31.0

--- a/src/mods/protocol/protocolcomponent.cairo
+++ b/src/mods/protocol/protocolcomponent.cairo
@@ -113,21 +113,29 @@ pub mod ProtocolCampagin {
         +Drop<TContractState>,
         impl Ownable: OwnableComponent::HasComponent<TContractState>
     > of IProtocol<ComponentState<TContractState>> {
-        /// @notice Create a new protocol campaign
 
+        /// @notice Create a new protocol campaign
         fn create_protocol_campaign(
             ref self: ComponentState<TContractState>, protocol_id: u256
         ) -> u256 {
             // Get the caller as the protocol owner by using the get_caller_address()
+            let protocol_owner = get_caller_address();
 
             // Read from state the protocol_nft_class_hash
+            let protocol_nft_class_hash = self.protocol_nft_class_hash.read();
 
             // Check if the protocol_id exist by reading from state i.e protocol_initialized
             // and also assert if it exist  Errors::PROTOCOL_ALREADY_EXIST
+            let protocol_initialized = self.protocol_initialized.read(protocol_id);
+            assert(!protocol_initialized, Errors::PROTOCOL_ALREADY_EXIST);
 
             // deploy protocol nft by calling the internal function _deploy_protocol_nft()
+            let salt = protocol_id.low.into(); // Using protocol_id.low as a simple salt for determinism
+            let protocol_nft_address = self._deploy_protocol_nft(protocol_owner, protocol_id, protocol_nft_class_hash, salt);
 
             // Create a protocol nft by calling the internal function _protocol_campaign()
+            let protocol_info = ""; // Placeholder; adjust if specific info is required
+            self._protocol_campaign(protocol_owner, protocol_nft_address, protocol_id, protocol_info);
 
             return protocol_id;
         }


### PR DESCRIPTION
# Implement Protocol Campaign Creation with Owner and NFT Handling

## Description
This PR implements the `create_protocol_campaign` function by implementing proper protocol owner assignment and NFT contract deployment functionality. The implementation ensures secure protocol creation with proper ownership tracking and automated NFT contract deployment for each campaign.

## Key Changes
- Added protocol owner assignment using `get_caller_address()`
- Implemented NFT contract deployment with protocol-specific class hash
- Added validation to prevent duplicate protocol creation
- Integrated event emission for protocol creation and NFT deployment

## Technical Implementation
- Protocol owner is set to the caller's address for ownership verification
- NFT contract is deployed using a deterministic salt based on protocol ID
- Protocol details are stored with proper initialization flags
- Events are emitted to track protocol creation and NFT deployment

## Security Considerations
- Validates protocol uniqueness to prevent duplicates
- Ensures proper ownership assignment
- Uses deterministic NFT deployment for predictable addresses
- Maintains protocol state consistency

## Related Issues
Closes #55