### PR TITLE
Added necessary tests

### DIFF
--- a/tests/test_protocol_component.cairo
+++ b/tests/test_protocol_component.cairo
@@ -1,26 +1,28 @@
+use core::byte_array::ByteArray;
 use core::option::OptionTrait;
 use core::result::ResultTrait;
-use core::traits::{TryInto};
-use core::byte_array::ByteArray;
-
-use starknet::{ContractAddress, get_block_timestamp, contract_address_const};
-
+use core::starknet::SyscallResultTrait;
+use core::starknet::syscalls::deploy_syscall;
+use core::traits::TryInto;
 use snforge_std::{
-    declare, start_cheat_caller_address, stop_cheat_caller_address, ContractClassTrait,
-    DeclareResultTrait, spy_events, EventSpyAssertionsTrait,
+    ContractClassTrait, DeclareResultTrait, EventSpyAssertionsTrait, declare, spy_events,
+    start_cheat_caller_address, stop_cheat_caller_address,
 };
-
-
+use starknet::{ContractAddress, contract_address_const, get_block_timestamp};
+use weaver_contract::mods::interfaces::ICustomNFT::{
+    ICustomNFTDispatcher, ICustomNFTDispatcherTrait,
+};
+use weaver_contract::mods::interfaces::Iprotocol::{IProtocolDispatcher, IProtocolDispatcherTrait};
 use weaver_contract::mods::protocol::protocolcomponent::ProtocolCampagin;
 use weaver_contract::mods::protocol::protocols::protocols;
-use weaver_contract::mods::interfaces::Iprotocol::{IProtocolDispatcher, IProtocolDispatcherTrait};
-use weaver_contract::mods::interfaces::ICustomNFT::{
-    ICustomNFTDispatcher, ICustomNFTDispatcherTrait
-};
 
-use core::starknet::syscalls::deploy_syscall;
-use core::starknet::SyscallResultTrait;
+fn USER() -> ContractAddress {
+    'recipient'.try_into().unwrap()
+}
 
+fn PROTOCOL() -> ContractAddress {
+    'protocol'.try_into().unwrap()
+}
 
 fn ___setup___() -> ContractAddress {
     // deploy protocol nft
@@ -42,5 +44,23 @@ fn test_create_protocol_campaign() {
     let protocol_contract_address = ___setup___();
 
     let protocol_dispatcher = IProtocolDispatcher { contract_address: protocol_contract_address };
+
+    let id: u256 = 111;
+    let mut protocol_info: ByteArray = "WEAVER";
+    let protocol = PROTOCOL();
+
+    start_cheat_caller_address(protocol_contract_address, protocol);
+    let create_campaign = protocol_dispatcher.create_protocol_campaign(id, protocol_info.clone());
+    assert!(create_campaign == 111, "Invalid protocol campaign id");
+
+    let protocol_data = protocol_dispatcher.get_protocol(id);
+    assert!(protocol_data.protocol_id == id, "Invalid protocol id");
+    assert!(protocol_data.protocol_owner == protocol, "Invalid protocol owner");
+    assert!(protocol_data.protocol_campaign_members == 0, "Invalid protocol campaign members");
+    assert!(
+        protocol_data.protocol_nft_address != contract_address_const::<0>(),
+        "protocol nft address is not deployed",
+    );
+    stop_cheat_caller_address(protocol_contract_address);
 }
 


### PR DESCRIPTION
## Test Implementation Summary: `create_protocol_campaign` Integration Test

### Key Changes and Approach

#### Test Setup
- Created a comprehensive integration test for the `create_protocol_campaign` function
- Used a predefined protocol contract address setup
- Initialized a protocol dispatcher using the contract address

#### Test Scenario
- Used a fixed campaign ID of `111`
- Set protocol information as "WEAVER"
- Simulated protocol caller address using `start_cheat_caller_address`

#### Assertions Implemented
1. Campaign Creation Validation
   - Verified the returned campaign ID matches the input
   - Checked protocol data retrieval after campaign creation

2. Protocol Data Verification
   - Confirmed protocol ID matches the input
   - Validated protocol owner matches expected address
   - Checked initial protocol campaign members count (0)
   - Ensured NFT address is properly deployed

#### Test Cleanup
- Used `stop_cheat_caller_address` to reset caller context

### Testing Objectives Achieved
- Covered normal creation scenario
- Validated input and output consistency
- Checked critical protocol campaign attributes
- Ensured proper contract interaction and state management

### Improvements from Original Requirements
- Comprehensive assertions covering multiple aspects
- Verified both direct function output and subsequent state
- Tested edge cases like initial member count and NFT deployment